### PR TITLE
Test runner should now close properly

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -11,8 +11,8 @@ app.use('/drafts', draftsApp);
 
 const port = process.env.PORT || 3000;
 
-app.listen(port, () => {
+const server = app.listen(port, () => {
   console.log(`API server listening on port ${port}`);
 });
 
-module.exports = app;
+module.exports = server;

--- a/backend/test/drafts.spec.js
+++ b/backend/test/drafts.spec.js
@@ -1,4 +1,4 @@
-const app = require('../index');
+const server = require('../index');
 const chai = require('chai');
 const chaiHttp = require('chai-http');
 
@@ -8,7 +8,7 @@ describe('/drafts', () => {
     // Test GET /drafts endpoint
     describe('GET /', () => {
         it('should return all drafts', (done) => {
-            chai.request(app)
+            chai.request(server)
                 .get('/drafts')
                 .end((err, res) => {
                     chai.expect(res).to.have.status(200);
@@ -25,7 +25,7 @@ describe('/drafts', () => {
                 title: 'My new draft',
                 body: 'This is the body of my new draft'
             };
-            chai.request(app)
+            chai.request(server)
                 .post('/drafts')
                 .send(draft)
                 .end((err, res) => {
@@ -46,13 +46,13 @@ describe('/drafts', () => {
                 title: 'My updated draft',
                 body: 'This is the updated body of my draft'
             };
-            chai.request(app)
+            chai.request(server)
                 .get('/drafts')
                 .end((err, res) => {
                     chai.expect(res).to.have.status(200);
                     chai.expect(res.body).to.be.an('array');
                     const id = res.body[0].id; // assuming at least one draft exists
-                    chai.request(app)
+                    chai.request(server)
                         .put(`/drafts/${id}`)
                         .send(draft)
                         .end((err, res) => {
@@ -70,17 +70,17 @@ describe('/drafts', () => {
     // Test DELETE /drafts/:id endpoint
     describe('DELETE /:id', () => {
         it('should delete an existing draft', (done) => {
-            chai.request(app)
+            chai.request(server)
                 .get('/drafts')
                 .end((err, res) => {
                     chai.expect(res).to.have.status(200);
                     chai.expect(res.body).to.be.an('array');
                     const id = res.body[0].id; // assuming at least one draft exists
-                    chai.request(app)
+                    chai.request(server)
                         .delete(`/drafts/${id}`)
                         .end((err, res) => {
                             chai.expect(res).to.have.status(200);
-                            chai.request(app)
+                            chai.request(server)
                                 .get(`/drafts/${id}`)
                                 .end((err, res) => {
                                     chai.expect(res).to.have.status(404);
@@ -88,6 +88,13 @@ describe('/drafts', () => {
                                 });
                         });
                 });
+        });
+    });
+
+    // Add after() hook to close the server
+    after((done) => {
+        server.close(() => {
+            done();
         });
     });
 });


### PR DESCRIPTION
fixes #13 

This pr fixes a small issue where the test runner wouldn't close backend server and thus reserve the assigned port until the container was terminated. This meant that if the tests were run twice they would fail, since the port assigned for the test server would not be available.

You can run the tests after launching the containers with the command `docker exec vtp-backend-1 npm test`. Note that exec command here isn't in detached mode with the argument `-d` and thus you still need to exit the test output with `ctrl + c`. Check the logs for a conversation about this with ChatGPT.

<details><summary>Chat logs</summary>

**You**: I have mocha/chai test set that tests a node.js backend running in a docker container, but there is a problem where after running 'docker exec &lt;container&gt; npm test' the test runner doesn't exit 

here's test code

```
const app = require('../index');
const chai = require('chai');
const chaiHttp = require('chai-http');

chai.use(chaiHttp);

describe('/drafts', () =&gt; {
    // Test GET /drafts endpoint
    describe('GET /', () =&gt; {
        it('should return all drafts', (done) =&gt; {
            chai.request(app)
                .get('/drafts')
                .end((err, res) =&gt; {
                    chai.expect(res).to.have.status(200);
                    chai.expect(res.body).to.be.an('array');
                    done();
                });
        });
    });

    // Test POST /drafts endpoint
    describe('POST /', () =&gt; {
        it('should create a new draft', (done) =&gt; {
            const draft = {
                title: 'My new draft',
                body: 'This is the body of my new draft'
            };
            chai.request(app)
                .post('/drafts')
                .send(draft)
                .end((err, res) =&gt; {
                    chai.expect(res).to.have.status(200);
                    chai.expect(res.body).to.be.an('object');
                    chai.expect(res.body).to.have.property('id');
                    chai.expect(res.body.title).to.equal(draft.title);
                    chai.expect(res.body.body).to.equal(draft.body);
                    done();
                });
        });
    });

    // Test PUT /drafts/:id endpoint
    describe('PUT /:id', () =&gt; {
        it('should update an existing draft', (done) =&gt; {
            const draft = {
                title: 'My updated draft',
                body: 'This is the updated body of my draft'
            };
            chai.request(app)
                .get('/drafts')
                .end((err, res) =&gt; {
                    chai.expect(res).to.have.status(200);
                    chai.expect(res.body).to.be.an('array');
                    const id = res.body[0].id; // assuming at least one draft exists
                    chai.request(app)
                        .put(`/drafts/${id}`)
                        .send(draft)
                        .end((err, res) =&gt; {
                            chai.expect(res).to.have.status(200);
                            chai.expect(res.body).to.be.an('object');
                            chai.expect(res.body.id).to.equal(id);
                            chai.expect(res.body.title).to.equal(draft.title);
                            chai.expect(res.body.body).to.equal(draft.body);
                            done();
                        });
                });
        });
    });

    // Test DELETE /drafts/:id endpoint
    describe('DELETE /:id', () =&gt; {
        it('should delete an existing draft', (done) =&gt; {
            chai.request(app)
                .get('/drafts')
                .end((err, res) =&gt; {
                    chai.expect(res).to.have.status(200);
                    chai.expect(res.body).to.be.an('array');
                    const id = res.body[0].id; // assuming at least one draft exists
                    chai.request(app)
                        .delete(`/drafts/${id}`)
                        .end((err, res) =&gt; {
                            chai.expect(res).to.have.status(200);
                            chai.request(app)
                                .get(`/drafts/${id}`)
                                .end((err, res) =&gt; {
                                    chai.expect(res).to.have.status(404);
                                    done();
                                });
                        });
                });
        });
    });
});
```

**ChatGPT**: One possible reason why the test runner doesn't exit could be that the node.js backend is still running after the tests have completed. This could happen if there are still open connections to the server, or if there are any ongoing background tasks that are not properly terminated.

One solution to this problem is to explicitly close the server after all the tests have completed. You can use the ```after()``` hook to run a function that shuts down the server, like this:scss
```scss
after((done) =&gt; {
  app.close(() =&gt; {
    done();
  });
});
```

This will close the server and call the ```done()``` callback function to signal to the test runner that the tests have completed.

Another possible reason why the test runner doesn't exit is that there is a bug or error in the test code that causes it to hang indefinitely. To debug this issue, you can try running the tests with the ```--inspect-brk``` flag to enable debugging in Chrome DevTools. Here's how you can do this:Start your node.js backend in debug mode:sql
```sql
docker exec -it &lt;container&gt; node --inspect-brk index.js
```In another terminal window, start the tests with the following command:python
```python
docker exec -it &lt;container&gt; node --inspect-brk node_modules/.bin/mocha
```

This will start the tests and open a Chrome DevTools window where you can debug the test code and see where it hangs.

I hope this helps you to identify and fix the issue with your test runner not exiting.

**You**: add the after() hook to the code in the first query, highlight all modifications you made with a line comment after the editted line.

**ChatGPT**: Sure, here's the updated code with the ```after()``` hook added:scss
```scss
const app = require('../index');
const chai = require('chai');
const chaiHttp = require('chai-http');

chai.use(chaiHttp);

describe('/drafts', () =&gt; {
    // Test GET /drafts endpoint
    describe('GET /', () =&gt; {
        it('should return all drafts', (done) =&gt; {
            chai.request(app)
                .get('/drafts')
                .end((err, res) =&gt; {
                    chai.expect(res).to.have.status(200);
                    chai.expect(res.body).to.be.an('array');
                    done();
                });
        });
    });

    // Test POST /drafts endpoint
    describe('POST /', () =&gt; {
        it('should create a new draft', (done) =&gt; {
            const draft = {
                title: 'My new draft',
                body: 'This is the body of my new draft'
            };
            chai.request(app)
                .post('/drafts')
                .send(draft)
                .end((err, res) =&gt; {
                    chai.expect(res).to.have.status(200);
                    chai.expect(res.body).to.be.an('object');
                    chai.expect(res.body).to.have.property('id');
                    chai.expect(res.body.title).to.equal(draft.title);
                    chai.expect(res.body.body).to.equal(draft.body);
                    done();
                });
        });
    });

    // Test PUT /drafts/:id endpoint
    describe('PUT /:id', () =&gt; {
        it('should update an existing draft', (done) =&gt; {
            const draft = {
                title: 'My updated draft',
                body: 'This is the updated body of my draft'
            };
            chai.request(app)
                .get('/drafts')
                .end((err, res) =&gt; {
                    chai.expect(res).to.have.status(200);
                    chai.expect(res.body).to.be.an('array');
                    const id = res.body[0].id; // assuming at least one draft exists
                    chai.request(app)
                        .put(`/drafts/${id}`)
                        .send(draft)
                        .end((err, res) =&gt; {
                            chai.expect(res).to.have.status(200);
                            chai.expect(res.body).to.be.an('object');
                            chai.expect(res.body.id).to.equal(id);
                            chai.expect(res.body.title).to.equal(draft.title);
                            chai.expect(res.body.body).to.equal(draft.body);
                            done();
                        });
                });
        });
    });

    // Test DELETE /drafts/:id endpoint
    describe('DELETE /:id', () =&gt; {
        it('should delete an existing draft', (done) =&gt; {
            chai.request(app)
                .get('/drafts')
                .end((err, res) =&gt; {
                    chai.expect(res).to.have.status(200);
                    chai.expect(res.body).to.be.an('array');
                    const id = res.body[0].id; // assuming at least one draft exists
                    chai.request(app)
                        .delete(`/drafts/${id}`)
                        .end((err, res) =&gt; {
                            chai.expect(res).to.have.status(200);
                            chai.request(app)
                                .get(`/drafts/${id}`)
                                .end((err, res) =&gt; {
                                    chai.expect(res).to.have.status(404);
                                    done();
                                });
                        });
                });
        });
    });

    // Add after() hook to close the server
    after((done) =&gt; { // added this line
        app.close(() =&gt; { // added this line
            done(); // added this line
        }); // added this line
    }); // added this line
});
``
```

**You**: I got error 'app.close is not a function' do I need to manually define it and what would it look like?

**ChatGPT**: If you're getting an error saying that ```app.close()``` is not a function, it means that the ```close()``` method is not defined in the ```app``` object.

The ```close()``` method is typically defined on a server object returned by the ```listen()``` method in Node.js. To fix the error, you need to modify the ```index.js``` file to return the server object instead of the ```app``` object.

Here's an example of how you can modify the ```index.js``` file to return the server object:javascript
```javascript
const express = require('express');
const app = express();

// Define routes here...

// Start the server and return the server object
const server = app.listen(3000, () =&gt; {
  console.log('Server listening on port 3000');
});

module.exports = server;
```

Then, in the test file, you can use the server object to close the server:scss
```scss
const server = require('../index');

// Add after() hook to close the server
after((done) =&gt; {
  server.close(() =&gt; {
    done();
  });
});
```

This should fix the error and allow you to close the server after running the tests.

**You**: the test runner seems close correctly now, but the docker exec command still doesn't exit automaticly but requires ctrl + c to escape, is there a fix to this

**ChatGPT**: If the ```docker exec``` command doesn't exit automatically after the tests have completed, it's likely because the Docker container is still running in the background.

One possible solution is to run the Docker container in "interactive" mode (```-i``` flag) and "detach" mode (```-d``` flag) at the same time. This allows you to run the ```npm test``` command inside the container, while still being able to detach from the container and return to your terminal session once the command is completed.

Here's an example of how you can modify the ```docker exec``` command to run the tests in "interactive" and "detach" mode:python
```python
docker exec -itd &lt;container&gt; sh -c "npm test &amp;&amp; exit"
```

This command runs the ```npm test``` command inside the container and then exits the container once the command is completed. The ```-itd``` flags enable interactive mode, TTY allocation, and detach mode at the same time.

With this command, you should be able to run the tests and detach from the container without having to manually interrupt the command with ```ctrl + c```.

**You**: But it doesn't print out the test results now

**ChatGPT**: If you want to see the test results while running the ```npm test``` command inside the Docker container in "interactive" and "detach" mode, you can redirect the output of the command to a log file and then tail the log file to see the results.

Here's an example of how you can modify the ```docker exec``` command to redirect the output to a log file:python
```python
docker exec -itd &lt;container&gt; sh -c "npm test &gt; /test.log &amp;&amp; exit"
```

This command runs the ```npm test``` command inside the container and redirects the output to a file called ```test.log```. The ```&amp;&amp; exit``` part of the command ensures that the container exits once the command is completed.

After running this command, you can tail the ```test.log``` file to see the test results:bash
```bash
docker exec -it &lt;container&gt; tail -f /test.log
```

This will show the test results as they are generated by the ```npm test``` command.

I hope this helps you to see the test results while running the command in "interactive" and "detach" mode.

**You**: I don't want to use a test.log file, but to see the test results in stadard output

**ChatGPT**: If you want to see the test results in the standard output of your terminal, you can run the ```npm test``` command in the foreground of the Docker container and use the ```docker logs``` command to view the container logs.

Here's an example of how you can modify the ```docker exec``` command to run the tests in the foreground:python
```python
docker exec -it &lt;container&gt; sh -c "npm test"
```

This command runs the ```npm test``` command inside the container in the foreground, which means that the test results will be printed to the standard output of the container.

To see the container logs, you can use the ```docker logs``` command:php
```php-template
docker logs -f &lt;container&gt;
```

This will show the logs generated by the container, including the test results.

Note that when running the tests in the foreground, you won't be able to detach from the container and return to your terminal session until the tests have completed. To interrupt the ```npm test``` command, you can use ```ctrl + c```.


</details>
