### PR TITLE
Issue #72 frontend changes

### DIFF
--- a/client/src/components/TargetTimeframe.js
+++ b/client/src/components/TargetTimeframe.js
@@ -31,7 +31,7 @@ const TargetTimeframe = ({ targetTimeframeData }) => {
 
             return (
               <tr key={item.id}>
-                <td>{index === 0 ? <Link to="/inspection-plan">Tarkastussuunnitelma</Link> : item.target_id}</td>
+                <td>{index === 0 ? <Link to="/inspection-plan">Tarkastussuunnitelma</Link> : item.goal}</td>
                 <td className={suunniteltuCellClass}>
                   <DatePicker selected={new Date(item.planned_date)} />
                 </td>


### PR DESCRIPTION
Closes #72

I was reviewing #73 and decided it would be easier to just fix the frontend myself. It was a good a good opportunity to also test out the new GPT-4 model of ChatGPT.

Logs relating this change below

<details><summary>Chat logs</summary>

**You**: I have a some react code that is supposed to show a table but is currently showing the wrong information, can you help?

**ChatGPT**: Of course, I'd be happy to help! Please provide the code you're working with, and let me know what's wrong or what you're trying to achieve. Once I have a better understanding of your issue, I can guide you through the troubleshooting process.

**You**: Can I add a picture

**ChatGPT**: Unfortunately, as a text-based AI, I'm unable to process images or view pictures. However, you can copy and paste the relevant code here as text, and I'll do my best to help you with your issue. Make sure to provide any necessary context or specific problems you're encountering.

**You**: Here's the React code
import React from 'react';
import './TargetTimeframe.css';
import DatePicker from 'react-datepicker';
import 'react-datepicker/dist/react-datepicker.css';
import { Link } from 'react-router-dom';

const TargetTimeframe = ({ targetTimeframeData }) => {
  const currentDate = new Date();

  return (
    <div className="target-timeframe-container">
      <h2>Tavoiteaikataulu</h2>
      <table className="target-timeframe-table">
        <thead>
          <tr>
            <th>Tavoite</th>
            <th>Suunniteltu pvm</th>
            <th>Toteutunut pvm</th>
            <th>Kommentit</th>
            <th>Linkki valmiseen dokumenttiin</th>
          </tr>
        </thead>
        <tbody>
          {targetTimeframeData.map((item, index) => {
            const suunniteltuDate = new Date(item.planned_date);
            let suunniteltuCellClass = '';

            if (suunniteltuDate < currentDate &amp;&amp; !item.actual_date) {
              suunniteltuCellClass = 'highlighted-date';
            }

            return (
              <tr key={item.id}>
                <td>{index === 0 ? <Link to="/inspection-plan">Tarkastussuunnitelma</Link> : item.target_id}</td>
                <td className={suunniteltuCellClass}>
                  <DatePicker selected={new Date(item.planned_date)} />
                </td>
                <td>
                  <DatePicker
                    selected={item.actual_date ? new Date(item.actual_date) : null}
                  />
                </td>
                <td>{item.comments}</td>
                <td>
                  {index === 0 ? (
                    <Link to="/inspection-plan">Linkki tarkastussuunnitelmaan</Link>
                  ) : (
                    <a href={item.document_id}>{item.document_id}</a>
                  )}</td>
              </tr>
            );
          })}
        </tbody>
      </table>
    </div>
  );
};

export default TargetTimeframe;

and here's the new fixed sql table for the infromation repredted in the react table
const targettimeframesSql = `
    CREATE TABLE IF NOT EXISTS targettimeframes (
      id INT AUTO_INCREMENT PRIMARY KEY,
      target_id INT NOT NULL,
      goal VARCHAR(255) NOT NULL,
      planned_date DATE NOT NULL,
      actual_date DATE DEFAULT NULL,
      comments VARCHAR(255) DEFAULT NULL,
      document_id INT DEFAULT NULL,
      link_text VARCHAR(255) DEFAULT NULL
    );

Fix the react code to show goal information in the 'Tavoite' column

**ChatGPT**: I see that you want to show the 'goal' information in the 'Tavoite' column of the table. To do this, you need to modify the React code to reference the 'goal' property of the item in the first cell of each row.

Here's the updated React code with the required change:javascript
```javascript
import React from 'react';
import './TargetTimeframe.css';
import DatePicker from 'react-datepicker';
import 'react-datepicker/dist/react-datepicker.css';
import { Link } from 'react-router-dom';

const TargetTimeframe = ({ targetTimeframeData }) => {
  const currentDate = new Date();

  return (
    <div className="target-timeframe-container">
      <h2>Tavoiteaikataulu</h2>
      <table className="target-timeframe-table">
        <thead>
          <tr>
            <th>Tavoite</th>
            <th>Suunniteltu pvm</th>
            <th>Toteutunut pvm</th>
            <th>Kommentit</th>
            <th>Linkki valmiseen dokumenttiin</th>
          </tr>
        </thead>
        <tbody>
          {targetTimeframeData.map((item, index) => {
            const suunniteltuDate = new Date(item.planned_date);
            let suunniteltuCellClass = '';

            if (suunniteltuDate < currentDate &amp;&amp; !item.actual_date) {
              suunniteltuCellClass = 'highlighted-date';
            }

            return (
              <tr key={item.id}>
                <td>{item.goal}</td> {/* Change made here */}
                <td className={suunniteltuCellClass}>
                  <DatePicker selected={new Date(item.planned_date)} />
                </td>
                <td>
                  <DatePicker
                    selected={item.actual_date ? new Date(item.actual_date) : null}
                  />
                </td>
                <td>{item.comments}</td>
                <td>
                  {index === 0 ? (
                    <Link to="/inspection-plan">Linkki tarkastussuunnitelmaan</Link>
                  ) : (
                    <a href={item.document_id}>{item.document_id}</a>
                  )}
                </td>
              </tr>
            );
          })}
        </tbody>
      </table>
    </div>
  );
};

export default TargetTimeframe;
```

I removed the conditional rendering for the 'Tavoite' column and replaced it with ```{item.goal}```. Now, the table will display the goal information in the 'Tavoite' column as desired.

**You**: Keep the conditional rendering, change the default case to item.goal. Just print out the return this time.

**ChatGPT**: I see, you want to keep the conditional rendering for the first item in the list and use ```item.goal``` as the default case. Here's the updated ```return``` statement with the required change:javascript
```javascript
return (
  <tr key={item.id}>
    <td>{index === 0 ? <Link to="/inspection-plan">Tarkastussuunnitelma</Link> : item.goal}</td>
    <td className={suunniteltuCellClass}>
      <DatePicker selected={new Date(item.planned_date)} />
    </td>
    <td>
      <DatePicker
        selected={item.actual_date ? new Date(item.actual_date) : null}
      />
    </td>
    <td>{item.comments}</td>
    <td>
      {index === 0 ? (
        <Link to="/inspection-plan">Linkki tarkastussuunnitelmaan</Link>
      ) : (
        <a href={item.document_id}>{item.document_id}</a>
      )}
    </td>
  </tr>
);
```

Now, the 'Tavoite' column will display the "Tarkastussuunnitelma" link for the first item in the list, and for the rest of the items, it will display the ```item.goal``` value.

**You**: Could you just tell me which line numbers need changes and what those changes are

**ChatGPT**: I apologize for any confusion. Here's a summary of the changes:Change the contents of the 'Tavoite' column (```<td>```) in the table row, which is on line 34.

Change this line:javascript
```javascript
<td>{index === 0 ? <Link to="/inspection-plan">Tarkastussuunnitelma</Link> : item.target_id}</td>
```

To:javascript
```javascript
<td>{index === 0 ? <Link to="/inspection-plan">Tarkastussuunnitelma</Link> : item.goal}</td>
```

This change keeps the conditional rendering for the first item (index 0) and displays the ```item.goal``` value for the rest of the items in the 'Tavoite' column.

**You**: I made the change, but the contents of item.goal aren't shown when the page is viewed

**ChatGPT**: If the contents of ```item.goal``` aren't being displayed, it's possible that the ```targetTimeframeData``` prop might not contain the expected data, or the data might not be properly mapped from your database to the ```goal``` property.

To investigate the issue, let's add a ```console.log()``` statement in the component to check the contents of the ```targetTimeframeData``` prop:javascript
```javascript
const TargetTimeframe = ({ targetTimeframeData }) => {
  const currentDate = new Date();

  console.log('targetTimeframeData:', targetTimeframeData); // Add this line to log the data

  // ... rest of the component
};
```

Now, when you run your application and open the browser console, you should see the logged ```targetTimeframeData```. Check if the ```goal``` property is present in each item and contains the expected data.

If the ```goal``` property is missing or has incorrect data, you should trace back to where you're fetching the data from the database and ensure that it's being mapped correctly.

In case the data is correct and the issue persists, you can share more information about your data-fetching mechanism or any relevant code, and I'll be happy to help you further.

**You**: Nevermind, the problem was caused by failed database update. Thanks for the input though.

**ChatGPT**: You're welcome! I'm glad you figured out the issue. If you have any more questions or need assistance with anything else, feel free to ask. Good luck with your project!

**You**: I made the changes in a branch that a created based on a pull request called pr73, Would like to return the to it's original state, while storing the changes to another branch.

**ChatGPT**: To revert the changes on the ```pr73``` branch and store the changes on a new branch, follow these steps:Make sure your working directory is clean by committing or stashing any changes.Check out the ```pr73``` branch: ```git checkout pr73```Create a new branch to store your changes, and switch to it: ```git checkout -b new-branch-name```Find the commit hash of the point where you want to revert the ```pr73``` branch to. You can use ```git log``` to find the appropriate commit hash.Switch back to the ```pr73``` branch: ```git checkout pr73```Revert the branch to the desired commit: ```git reset --hard <commit-hash>```

This will revert the ```pr73``` branch to its original state, and your changes will be saved in the new branch you created.

Important: Using ```git reset --hard``` can result in a loss of committed work. Make sure you double-check the commit hash and that your changes are safely stored in the new branch before executing this command.

After completing these steps, you'll have the ```pr73``` branch in its original state and a new branch with the changes you made.


</details>
