### PR TITLE
Update MySQL connection to use Docker service name as fallback

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -19,4 +19,4 @@ ENV DB_NAME=mydatabase
 EXPOSE ${PORT}
 
 # Start server
-CMD [ "./wait-for-it.sh", "db:3306", "-t", "0", "--", "npm", "start" ]
+CMD [ "./wait-for-it.sh", "db:3306", "-t", "60", "--", "npm", "start" ]

--- a/backend/db.js
+++ b/backend/db.js
@@ -8,11 +8,12 @@ const connection = mysql.createConnection({
   multipleStatements: true
 });
 
-connection.connect((error) => {
-  if (error) {
-    console.error('Error connecting to database:', error);
+connection.connect(function (err) {
+  if (err) {
+    console.error('Error connecting to database:', err);
+    setTimeout(connectToDatabase, 5000); // Retry after 5 seconds
   } else {
-    console.log('Connected to database');
+    console.log('Connected to the database.');
   }
 });
 

--- a/backend/db.js
+++ b/backend/db.js
@@ -1,7 +1,7 @@
 const mysql = require('mysql');
 
 const connection = mysql.createConnection({
-  host: process.env.DB_HOST || 'localhost',
+  host: process.env.DB_HOST || 'db',
   user: process.env.DB_USER || 'root',
   password: process.env.DB_PASSWORD || 'secret',
   database: process.env.DB_NAME || 'mydatabase',


### PR DESCRIPTION
Closes #114 

This pull request updates the MySQL connection configuration in the backend to use the Docker service name 'db' as the fallback host instead of 'localhost'. This change ensures that the backend correctly connects to the MySQL container in a Docker environment when the DB_HOST environment variable is not set.

Changes:
- Updated the mysql.createConnection function in the backend to use 'db' as the fallback value for the host property.

<details><summary>Chat logs</summary>

**You**: Here's how I'm currently connectign to mysql database
´´´
const connection = mysql.createConnection({
  host: process.env.DB_HOST || 'localhost',
  user: process.env.DB_USER || 'root',
  password: process.env.DB_PASSWORD || 'secret',
  database: process.env.DB_NAME || 'mydatabase',
  multipleStatements: true
});
´´´
I have feeling this is causing issue because the database is in a different container within the same docker compsoe created network
here's the docker compose 
´´´
version: '3'
services:
  db:  
    image: mysql:5.6
    restart: always
    environment:
      MYSQL_ROOT_PASSWORD: secret
      MYSQL_DATABASE: mydatabase
    volumes:
      - db_data:/var/lib/mysql
      - ./init-scripts:/docker-entrypoint-initdb.d
  backend:
    build: ./backend
    ports:
      - "8080:3000"
    depends_on:
      - db
    environment:
      DB_HOST: db
      DB_USER: root
      DB_PASSWORD: secret
      DB_NAME: mydatabase
  frontend:
    build: ./client
    ports:
      - "3000:3000"
volumes:
  db_data:
´´´

**ChatGPT**: It looks like your code should work correctly as you have specified the correct environment variables in the docker-compose file. However, sometimes, the backend container starts before the database is fully initialized and ready to accept connections, causing connection issues.

To address this problem, you can use the ```wait-for-it.sh``` script, which waits for a specific host and port to be available before executing a command.

Here's how you can modify your docker-compose file to use ```wait-for-it.sh```:

First, download the ```wait-for-it.sh``` script from here and save it in your backend folder.

Make the script executable by running:bash
```bash
chmod +x ./backend/wait-for-it.sh
```

Modify your Dockerfile in the backend folder to copy the ```wait-for-it.sh``` script:perl
```perl
# Add this line after copying your other files
COPY wait-for-it.sh /wait-for-it.sh
```

Update your docker-compose file to use the ```wait-for-it.sh``` script for the ```backend``` service:yaml
```yaml
version: '3'
services:
  db:  
    image: mysql:5.6
    restart: always
    environment:
      MYSQL_ROOT_PASSWORD: secret
      MYSQL_DATABASE: mydatabase
    volumes:
      - db_data:/var/lib/mysql
      - ./init-scripts:/docker-entrypoint-initdb.d
  backend:
    build: ./backend
    ports:
      - "8080:3000"
    depends_on:
      - db
    environment:
      DB_HOST: db
      DB_USER: root
      DB_PASSWORD: secret
      DB_NAME: mydatabase
    command: ["/wait-for-it.sh", "db:3306", "--", "npm", "start"] # Add this line
  frontend:
    build: ./client
    ports:
      - "3000:3000"
volumes:
  db_data:
```

With these changes, your backend container will wait until the MySQL container is ready to accept connections before starting the application.

**You**: What about using 'localhost' to connect to the container?

**ChatGPT**: Using 'localhost' to connect to the container will not work in this case because your MySQL database is running in a separate container, and 'localhost' refers to the current container. In a Docker environment, each container is isolated and has its own network stack. So, when you use 'localhost', you're referring to the local container, not the host or other containers.

In your docker-compose file, you have defined the MySQL container as a service named 'db'. Docker Compose creates a network between the containers and sets up hostname resolution using the service names. That's why you should use the service name 'db' as the hostname when connecting to the MySQL container from your backend container.

In your current configuration, you are already setting the ```DB_HOST``` environment variable correctly to 'db' in the backend service:yaml
```yaml
backend:
  ...
  environment:
    DB_HOST: db
    ...
```

So, your backend container should be able to connect to the MySQL container using the service name 'db' as the hostname. Make sure you don't override this value with 'localhost' in your code.

**You**: make the change to this function
´´´
const connection = mysql.createConnection({
  host: process.env.DB_HOST || 'localhost',
  user: process.env.DB_USER || 'root',
  password: process.env.DB_PASSWORD || 'secret',
  database: process.env.DB_NAME || 'mydatabase',
  multipleStatements: true
});
´´´

**ChatGPT**: To ensure your code correctly connects to the MySQL container using the environment variables defined in your ```docker-compose.yml``` file, you can update the function like this:javascript
```javascript
const connection = mysql.createConnection({
  host: process.env.DB_HOST || 'db', // Changed 'localhost' to 'db'
  user: process.env.DB_USER || 'root',
  password: process.env.DB_PASSWORD || 'secret',
  database: process.env.DB_NAME || 'mydatabase',
  multipleStatements: true
});
```

By changing the fallback value from ```'localhost'``` to ```'db'```, you ensure that the application will try to connect to the MySQL container using the service name 'db' if the ```DB_HOST``` environment variable is not set. This way, even if the environment variable is missing, your code should still work correctly when running in a Docker environment.

However, if you plan to run your application outside of Docker, you might need to change the fallback value back to ```'localhost'``` or set the appropriate environment variables manually before starting your application.


</details>
