### PR TITLE
Upgrade MySQL Database Container from 5.6 to 5.7.41

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   db:  
-    image: mysql:5.6
+    image: mysql:5.7.41
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: secret


### PR DESCRIPTION
Work on #85 

This pull request upgrades the MySQL database container from version 5.6 to 5.7.41. The upgrade introduces some changes that impact the backend tests, causing some to fail. The following list highlights the primary changes and their impacts:
- SQL mode changes: New default SQL modes in MySQL 5.7 may cause compatibility issues. The queries need to be updated to comply with the new SQL modes or set the SQL mode in the MySQL configuration to match the modes from 5.6.
- Reserved keywords: New reserved keywords added in MySQL 5.7 may cause issues if not escaped properly. Update the queries using the newly added reserved keywords.
- STRICT mode: MySQL 5.7 enables STRICT mode by default, enforcing strict data validation. Update test data to comply with table constraints or disable STRICT mode as required.
- JSON data type: MySQL 5.7 introduces the JSON data type, which may cause issues if the code expects a TEXT data type for storing JSON. Update the code to handle JSON data types correctly.
- Changes in default behavior: MySQL 5.7 includes changes in default behavior, such as default sorting for GROUP BY. Update queries to accommodate these changes.

To ensure a smooth transition, it is essential to address the issues causing the backend tests to fail. Review the error messages from the failing tests and check the MySQL error logs to identify specific issues and address them accordingly.

Developer's note: no point fixing the tests now since they will need to be fixed again for the merging of schema_upgrade branch.

<details><summary>Chat logs</summary>

**You**: I upgrade mysql database container from 5.6 to 5.7.41. This caused some of my backend tests to fail

**ChatGPT**: Upgrading MySQL from version 5.6 to 5.7.41 could cause several issues that might lead to failing backend tests. Here are some common reasons and solutions:

SQL mode changes: MySQL 5.7 introduces some new default SQL modes which could be causing compatibility issues. To resolve this, you can either modify your queries to comply with the new SQL modes or explicitly set the SQL mode in your MySQL configuration to match the modes from 5.6.

Reserved keywords: Some new reserved keywords were added in MySQL 5.7. If your queries use these keywords without proper escaping (backticks), this could lead to issues. Check the list of reserved keywords in MySQL 5.7 and modify your queries accordingly.

STRICT mode: MySQL 5.7 enables STRICT mode by default, which enforces strict data validation for input values. If your tests involve inserting data that violates the table constraints, you may encounter errors. Update your test data to comply with table constraints or disable STRICT mode if needed.

JSON data type: MySQL 5.7 introduces the JSON data type, which could cause issues if your existing code expects a TEXT data type for storing JSON. Update your code to handle JSON data types correctly.

Changes in default behavior: MySQL 5.7 comes with some changes in default behavior, such as default sorting for GROUP BY, which may affect your queries. Review the release notes of MySQL 5.7 and update your queries accordingly.

To troubleshoot further, review the error messages from the failing tests and check the MySQL error logs for additional information. This will help you identify the specific issues caused by the upgrade and address them accordingly.

**You**: Summarise the change and how its impacts as a pull request

**ChatGPT**: Title: Upgrade MySQL Database Container from 5.6 to 5.7.41

Description:

This pull request upgrades the MySQL database container from version 5.6 to 5.7.41. The upgrade introduces some changes that impact the backend tests, causing some to fail. The following list highlights the primary changes and their impacts:SQL mode changes: New default SQL modes in MySQL 5.7 may cause compatibility issues. The queries need to be updated to comply with the new SQL modes or set the SQL mode in the MySQL configuration to match the modes from 5.6.Reserved keywords: New reserved keywords added in MySQL 5.7 may cause issues if not escaped properly. Update the queries using the newly added reserved keywords.STRICT mode: MySQL 5.7 enables STRICT mode by default, enforcing strict data validation. Update test data to comply with table constraints or disable STRICT mode as required.JSON data type: MySQL 5.7 introduces the JSON data type, which may cause issues if the code expects a TEXT data type for storing JSON. Update the code to handle JSON data types correctly.Changes in default behavior: MySQL 5.7 includes changes in default behavior, such as default sorting for GROUP BY. Update queries to accommodate these changes.

To ensure a smooth transition, it is essential to address the issues causing the backend tests to fail. Review the error messages from the failing tests and check the MySQL error logs to identify specific issues and address them accordingly.


</details>
