### PR TITLE
Modify the inspection view to show tables correctly

### DIFF
--- a/client/src/components/InspectionInformation.css
+++ b/client/src/components/InspectionInformation.css
@@ -1,27 +1,18 @@
-.InspectionInformation {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
+  .inspection-information {
+    width: calc(50% - 10px);
+    float: left;
   }
   
-  .title {
-    margin: 20px 0;
-    font-size: 20px;
-    font-weight: bold;
-    text-align: center;
-  }
-  
-  table {
+  .inspection-information-table {
     width: 100%;
     border-collapse: collapse;
-    margin-top: 20px;
+    margin-top: 10px;
   }
   
   th, td {
     border: 1px solid black;
     padding: 10px;
     text-align: left;
-    width: 50%;
   }
   
   th {
@@ -29,13 +20,5 @@
     font-weight: bold;
     padding: 12px;
     text-align: left;
+    width: 50%;
   }
-  
-  tr:nth-child(odd) {
-    background-color: #eee;
-  }
-  
-  tr:nth-child(even) {
-    background-color: white;
-  }
-  

--- a/client/src/components/LatestDocuments.css
+++ b/client/src/components/LatestDocuments.css
@@ -1,6 +1,7 @@
 .latest-documents {
-    width: 50%;
+    width: calc(50% - 10px);
     float: left;
+    margin-left: 20px;
   }
   
   table {

--- a/client/src/components/TargetTimeframe.css
+++ b/client/src/components/TargetTimeframe.css
@@ -11,7 +11,6 @@
   }
   
   .target-timeframe-table {
-    border-collapse: collapse;
     width: 100%;
     margin-bottom: 20px;
   }
@@ -21,29 +20,6 @@
   .target-timeframe-table th:nth-child(3),
   .target-timeframe-table td:nth-child(3) {
       width: 100px;
-  }
-  
-  .target-timeframe-table th,
-  .target-timeframe-table td {
-    padding: 5px;
-    border: 1px solid black;
-  }
-  
-  .target-timeframe-table th {
-    background-color: #444;
-    color: white;
-  }
-  
-  .target-timeframe-table tr:nth-child(odd) {
-    background-color: #f8f8f8;
-  }
-  
-  .target-timeframe-table tr:nth-child(even) {
-    background-color: white;
-  }
-  
-  .target-timeframe-table tr:hover {
-    background-color: #ddd;
   }
 
   .target-timeframe-table .highlighted-date {


### PR DESCRIPTION
Small changes to css files to show the tables on inspection view correcly.


[Small ui fixes to show tables correctly GPT-4.md](https://github.com/AI-Makes-IT/VTP/files/11161575/Small.ui.fixes.to.show.tables.correctly.GPT-4.md)
