### PR TITLE
Update Tests for Drafts API and Fix Route Queries

### DIFF
--- a/backend/drafts.js
+++ b/backend/drafts.js
@@ -6,20 +6,20 @@ function setupDraftsRoute(app) {
   app.post('/api/drafts', async (req, res) => {
     const { subject_id } = req.body;
     try {
-        const result = await db.query('INSERT INTO drafts (subject_id) VALUES (?)', [subject_id]);
-        res.status(201).json({ id: result[0].insertId });
+      const result = await db.query('INSERT INTO drafts (subject_id) VALUES (?)', [subject_id]);
+      res.status(201).json({ id: result[0].insertId });
     } catch (err) {
-        res.status(500).json({ error: 'Error creating draft' });
+      res.status(500).json({ error: 'Error creating draft' });
     }
   });
 
 
   app.get('/api/drafts', async (req, res) => {
     try {
-        const result = await db.query('SELECT * FROM drafts');
-        res.status(200).json(result);
+      const [result] = await db.query('SELECT * FROM drafts');
+      res.status(200).json(result);
     } catch (err) {
-        res.status(500).json({ error: 'Error fetching drafts' });
+      res.status(500).json({ error: 'Error fetching drafts' });
     }
   });
 
@@ -27,7 +27,7 @@ function setupDraftsRoute(app) {
   app.get('/api/drafts/:id', async (req, res) => {
     const { id } = req.params;
     try {
-      const [rows] = await db.query('SELECT drafts.id, drafts.subject_id, inspection_information.* FROM drafts JOIN inspection_information ON drafts.id = inspection_information.draft_id WHERE drafts.id = ?', [id]);
+      const [rows] = await db.query('SELECT drafts.id AS d_id, drafts.subject_id, inspection_information.* FROM drafts JOIN inspection_information ON drafts.id = inspection_information.draft_id WHERE drafts.id = ?', [id]);
       if (rows.length === 0) {
         res.status(404).json({ error: 'Draft not found' });
       } else {
@@ -42,7 +42,7 @@ function setupDraftsRoute(app) {
   app.delete('/api/drafts/:id', async (req, res) => {
     const { id } = req.params;
     try {
-      const result = await db.query('DELETE FROM drafts WHERE id = ?', [id]);
+      const [result] = await db.query('DELETE FROM drafts WHERE id = ?', [id]);
       if (result.affectedRows === 0) {
         res.status(404).json({ error: 'Draft not found' });
       } else {
@@ -57,7 +57,7 @@ function setupDraftsRoute(app) {
     const { id } = req.params;
     try {
       // Fetch draft and its inspection information
-      const [draftRows] = await db.query('SELECT drafts.id, drafts.subject_id, inspection_information.* FROM drafts JOIN inspection_information ON drafts.id = inspection_information.draft_id WHERE drafts.id = ?', [id]);
+      const [draftRows] = await db.query('SELECT drafts.id AS d_id, drafts.subject_id, inspection_information.* FROM drafts JOIN inspection_information ON drafts.id = inspection_information.draft_id WHERE drafts.id = ?', [id]);
       if (draftRows.length === 0) {
         res.status(404).json({ error: 'Draft not found' });
         return;
@@ -85,6 +85,7 @@ function setupDraftsRoute(app) {
       res.status(500).json({ error: 'Error retrieving full draft information' });
     }
   });
+
 
 
 }

--- a/backend/drafts.js
+++ b/backend/drafts.js
@@ -6,10 +6,20 @@ function setupDraftsRoute(app) {
   app.post('/api/drafts', async (req, res) => {
     const { subject_id } = req.body;
     try {
-      const result = await db.query('INSERT INTO drafts (subject_id) VALUES (?)', [subject_id]);
-      res.status(201).json({ id: result.insertId });
+        const result = await db.query('INSERT INTO drafts (subject_id) VALUES (?)', [subject_id]);
+        res.status(201).json({ id: result[0].insertId });
     } catch (err) {
-      res.status(500).json({ error: 'Error creating draft' });
+        res.status(500).json({ error: 'Error creating draft' });
+    }
+  });
+
+
+  app.get('/api/drafts', async (req, res) => {
+    try {
+        const result = await db.query('SELECT * FROM drafts');
+        res.status(200).json(result);
+    } catch (err) {
+        res.status(500).json({ error: 'Error fetching drafts' });
     }
   });
 
@@ -25,22 +35,6 @@ function setupDraftsRoute(app) {
       }
     } catch (err) {
       res.status(500).json({ error: 'Error retrieving draft' });
-    }
-  });
-
-
-  app.put('/api/drafts/:id', async (req, res) => {
-    const { id } = req.params;
-    const { subject_id } = req.body;
-    try {
-      const result = await db.query('UPDATE drafts SET subject_id = ? WHERE id = ?', [subject_id, id]);
-      if (result.affectedRows === 0) {
-        res.status(404).json({ error: 'Draft not found' });
-      } else {
-        res.status(200).json({ message: 'Draft updated successfully' });
-      }
-    } catch (err) {
-      res.status(500).json({ error: 'Error updating draft' });
     }
   });
 

--- a/backend/test/drafts.spec.js
+++ b/backend/test/drafts.spec.js
@@ -1,88 +1,151 @@
-const server = require('../index');
 const chai = require('chai');
 const chaiHttp = require('chai-http');
-
+const app = require('../index');
+const expect = chai.expect;
+const request = chai.request;
+const db = require('../db');
 chai.use(chaiHttp);
 
 describe('/drafts', () => {
-    let createdDraftId;
+    let createdSubjectId, createdDraftId, createdInspectionInfoId, createdTargetTimeframeId, createdDocumentId, createdSchedulingId;
 
-    beforeEach((done) => {
-        const draft = {
-            subject_id: 1
-        };
-        chai.request(server)
-            .post('/api/drafts')
-            .send(draft)
-            .end((err, res) => {
-                chai.expect(res).to.have.status(201);
-                chai.expect(res.body).to.be.an('object');
-                chai.expect(res.body).to.have.property('id');
-                createdDraftId = res.body.id;
-                done();
-            });
+    before(async () => {
+        // Clear database tables before starting tests
+        await db.query('DELETE FROM target_timeframes');
+        await db.query('DELETE FROM documents');
+        await db.query('DELETE FROM scheduling');
+        await db.query('DELETE FROM inspection_information');
+        await db.query('DELETE FROM drafts');
+        await db.query('DELETE FROM inspection_subject');
     });
 
-    // Test GET /drafts endpoint
-    describe('GET /api/drafts', () => {
-        it('should return all drafts', (done) => {
-            chai.request(server)
-                .get('/api/drafts')
-                .end((err, res) => {
-                    chai.expect(res).to.have.status(200);
-                    chai.expect(res.body).to.be.an('array');
-                    done();
-                });
-        });
+    beforeEach(async () => {
+        // Add data needed for the tests
+        const [subjectResult] = await db.query("INSERT INTO inspection_subject (name) VALUES ('Test Subject')");
+        createdSubjectId = subjectResult.insertId;
+
+        const [draftResult] = await db.query("INSERT INTO drafts (subject_id) VALUES (?)", [createdSubjectId]);
+        createdDraftId = draftResult.insertId;
+
+        const [inspectionInfoResult] = await db.query(`INSERT INTO inspection_information (draft_id, subject_of_inspection, issue, risk_area, official_duration_period, total_duration_period, participants, responsible_inspector, office, department, subject_contact_information, inspection_contact_person)
+                            VALUES (?, 'Test Inspection', 'Test issue', 'Test risk area', '1 week', '1 week', 'John Doe', 'Inspector', 'Office', 'Department', 'Subject contact info', 'Contact person')`, [createdDraftId]);
+        createdInspectionInfoId = inspectionInfoResult.insertId;
+
+        const [targetTimeframeResult] = await db.query("INSERT INTO target_timeframes (draft_id, goal, planned_date) VALUES (?, 'Test Goal', '2023-01-01')", [createdDraftId]);
+        createdTargetTimeframeId = targetTimeframeResult.insertId;
+
+        const [documentResult] = await db.query("INSERT INTO documents (draft_id, title) VALUES (?, 'Test Document')", [createdDraftId]);
+        createdDocumentId = documentResult.insertId;
+
+        const [schedulingResult] = await db.query("INSERT INTO scheduling (draft_id, event, person, week) VALUES (?, 'Test Event', 'John Doe', 1)", [createdDraftId]);
+        createdSchedulingId = schedulingResult.insertId;
     });
 
-    // Test POST /drafts endpoint
+    afterEach(async () => {
+        // Clear database tables after each test
+        await db.query('DELETE FROM target_timeframes');
+        await db.query('DELETE FROM documents');
+        await db.query('DELETE FROM scheduling');
+        await db.query('DELETE FROM inspection_information');
+        await db.query('DELETE FROM drafts');
+        await db.query('DELETE FROM inspection_subject');
+    });
+
     describe('POST /api/drafts', () => {
-        it('should create a new draft', (done) => {
-            const draft = {
-                subject_id: 1
-            };
-            chai.request(server)
+        it('should create a new draft and return its id', async () => {
+            const res = await request(app)
                 .post('/api/drafts')
-                .send(draft)
-                .end((err, res) => {
-                    chai.expect(res).to.have.status(201); // Updated to 201, as that's the status code in the API for successful creation
-                    chai.expect(res.body).to.be.an('object');
-                    chai.expect(res.body).to.have.property('id');
-                    done();
-                });
+                .send({ subject_id: createdSubjectId });
+
+            expect(res.status).to.equal(201);
+            expect(res.body).to.have.property('id');
+            expect(res.body.id).to.be.a('number');
+
+            // Check if the draft was actually created
+            const [rows] = await db.query('SELECT * FROM drafts WHERE id = ?', [res.body.id]);
+            expect(rows.length).to.equal(1);
+            expect(rows[0].subject_id).to.equal(createdSubjectId);
         });
     });
 
-    // Test DELETE /drafts/:id endpoint
+
+    describe('GET /api/drafts', () => {
+        it('should return a list of drafts', async () => {
+            const res = await request(app).get('/api/drafts');
+
+            expect(res.status).to.equal(200);
+            expect(res.body).to.be.an('array');
+            expect(res.body.length).to.be.at.least(1);
+
+            // Check if the created draft is in the list
+            const createdDraft = res.body.find((draft) => draft.id === createdDraftId);
+            expect(createdDraft).to.exist;
+            expect(createdDraft.subject_id).to.equal(createdSubjectId);
+        });
+    });
+
+
+    describe('GET /api/drafts/:id', () => {
+        it('should return the draft with the specified id', async () => {
+            const res = await request(app).get(`/api/drafts/${createdDraftId}`);
+
+            expect(res.status).to.equal(200);
+            expect(res.body).to.be.an('object');
+            expect(res.body).to.have.property('d_id', createdDraftId);
+            expect(res.body).to.have.property('subject_id', createdSubjectId);
+        });
+
+        it('should return a 404 error if the draft does not exist', async () => {
+            const nonExistentId = createdDraftId + 100;
+            const res = await request(app).get(`/api/drafts/${nonExistentId}`);
+
+            expect(res.status).to.equal(404);
+            expect(res.body).to.have.property('error', 'Draft not found');
+        });
+    });
+
+
     describe('DELETE /api/drafts/:id', () => {
-        it('should delete an existing draft', (done) => {
-            chai.request(server)
-                .get(`/api/drafts/${createdDraftId}/full`)
-                .end((err, res) => {
-                    chai.expect(res).to.have.status(200);
-                    chai.expect(res.body).to.be.an('array');
-                    const id = res.body[0].id; // assuming at least one draft exists
-                    chai.request(server)
-                        .delete(`/api/drafts/${id}`)
-                        .end((err, res) => {
-                            chai.expect(res).to.have.status(200);
-                            chai.request(server)
-                                .get(`/api/drafts/${id}`)
-                                .end((err, res) => {
-                                    chai.expect(res).to.have.status(404);
-                                    done();
-                                });
-                        });
-                });
+        it('should delete an existing draft', async () => {
+            const res = await request(app).delete(`/api/drafts/${createdDraftId}`);
+
+            expect(res.status).to.equal(200);
+            expect(res.body).to.have.property('message', 'Draft deleted successfully');
+
+            // Check if the draft was actually deleted
+            const [rows] = await db.query('SELECT * FROM drafts WHERE id = ?', [createdDraftId]);
+            expect(rows.length).to.equal(0);
+        });
+
+        it('should return a 404 error if the draft does not exist', async () => {
+            const nonExistentId = createdDraftId + 100;
+            const res = await request(app).delete(`/api/drafts/${nonExistentId}`);
+
+            expect(res.status).to.equal(404);
+            expect(res.body).to.have.property('error', 'Draft not found');
         });
     });
-    
 
-    // Add after() hook to close the server
-    after((done) => {
-        server.close(() => {
-            done();
+
+    describe('GET /api/drafts/:id/full', () => {
+        it('should return the full draft information with the specified id', async () => {
+            const res = await request(app).get(`/api/drafts/${createdDraftId}/full`);
+
+            expect(res.status).to.equal(200);
+            expect(res.body).to.be.an('object');
+            expect(res.body).to.have.property('d_id', createdDraftId);
+            expect(res.body).to.have.property('subject_id', createdSubjectId);
+            expect(res.body).to.have.property('target_timeframes').that.is.an('array');
+            expect(res.body).to.have.property('documents').that.is.an('array');
+            expect(res.body).to.have.property('scheduling').that.is.an('array');
+        });
+
+        it('should return a 404 error if the draft does not exist', async () => {
+            const nonExistentId = createdDraftId + 100;
+            const res = await request(app).get(`/api/drafts/${nonExistentId}/full`);
+
+            expect(res.status).to.equal(404);
+            expect(res.body).to.have.property('error', 'Draft not found');
         });
     });
 });

--- a/backend/test/drafts.spec.js
+++ b/backend/test/drafts.spec.js
@@ -5,11 +5,29 @@ const chaiHttp = require('chai-http');
 chai.use(chaiHttp);
 
 describe('/drafts', () => {
+    let createdDraftId;
+
+    beforeEach((done) => {
+        const draft = {
+            subject_id: 1
+        };
+        chai.request(server)
+            .post('/api/drafts')
+            .send(draft)
+            .end((err, res) => {
+                chai.expect(res).to.have.status(201);
+                chai.expect(res.body).to.be.an('object');
+                chai.expect(res.body).to.have.property('id');
+                createdDraftId = res.body.id;
+                done();
+            });
+    });
+
     // Test GET /drafts endpoint
-    describe('GET /', () => {
+    describe('GET /api/drafts', () => {
         it('should return all drafts', (done) => {
             chai.request(server)
-                .get('/drafts')
+                .get('/api/drafts')
                 .end((err, res) => {
                     chai.expect(res).to.have.status(200);
                     chai.expect(res.body).to.be.an('array');
@@ -19,69 +37,38 @@ describe('/drafts', () => {
     });
 
     // Test POST /drafts endpoint
-    describe('POST /', () => {
+    describe('POST /api/drafts', () => {
         it('should create a new draft', (done) => {
             const draft = {
-                title: 'My new draft',
-                body: 'This is the body of my new draft'
+                subject_id: 1
             };
             chai.request(server)
-                .post('/drafts')
+                .post('/api/drafts')
                 .send(draft)
                 .end((err, res) => {
-                    chai.expect(res).to.have.status(200);
+                    chai.expect(res).to.have.status(201); // Updated to 201, as that's the status code in the API for successful creation
                     chai.expect(res.body).to.be.an('object');
                     chai.expect(res.body).to.have.property('id');
-                    chai.expect(res.body.title).to.equal(draft.title);
-                    chai.expect(res.body.body).to.equal(draft.body);
                     done();
                 });
         });
     });
 
-    // Test PUT /drafts/:id endpoint
-    describe('PUT /:id', () => {
-        it('should update an existing draft', (done) => {
-            const draft = {
-                title: 'My updated draft',
-                body: 'This is the updated body of my draft'
-            };
-            chai.request(server)
-                .get('/drafts')
-                .end((err, res) => {
-                    chai.expect(res).to.have.status(200);
-                    chai.expect(res.body).to.be.an('array');
-                    const id = res.body[0].id; // assuming at least one draft exists
-                    chai.request(server)
-                        .put(`/drafts/${id}`)
-                        .send(draft)
-                        .end((err, res) => {
-                            chai.expect(res).to.have.status(200);
-                            chai.expect(res.body).to.be.an('object');
-                            chai.expect(res.body.id).to.equal(id);
-                            chai.expect(res.body.title).to.equal(draft.title);
-                            chai.expect(res.body.body).to.equal(draft.body);
-                            done();
-                        });
-                });
-        });
-    });
-
     // Test DELETE /drafts/:id endpoint
-    describe('DELETE /:id', () => {
+    describe('DELETE /api/drafts/:id', () => {
         it('should delete an existing draft', (done) => {
             chai.request(server)
-                .get('/drafts')
+                .get(`/api/drafts/${createdDraftId}/full`)
                 .end((err, res) => {
                     chai.expect(res).to.have.status(200);
                     chai.expect(res.body).to.be.an('array');
                     const id = res.body[0].id; // assuming at least one draft exists
                     chai.request(server)
-                        .delete(`/drafts/${id}`)
+                        .delete(`/api/drafts/${id}`)
                         .end((err, res) => {
                             chai.expect(res).to.have.status(200);
                             chai.request(server)
-                                .get(`/drafts/${id}`)
+                                .get(`/api/drafts/${id}`)
                                 .end((err, res) => {
                                     chai.expect(res).to.have.status(404);
                                     done();
@@ -90,6 +77,7 @@ describe('/drafts', () => {
                 });
         });
     });
+    
 
     // Add after() hook to close the server
     after((done) => {

--- a/init-scripts/init-script.sql
+++ b/init-scripts/init-script.sql
@@ -24,7 +24,7 @@ CREATE TABLE inspection_subject (
 CREATE TABLE IF NOT EXISTS drafts (
   id INT AUTO_INCREMENT PRIMARY KEY,
   subject_id INT NOT NULL,
-  CONSTRAINT fk_drafts_subjects FOREIGN KEY (subject_id) REFERENCES inspection_subject(id)
+  CONSTRAINT fk_drafts_subjects FOREIGN KEY (subject_id) REFERENCES inspection_subject(id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS inspection_information (
@@ -41,7 +41,7 @@ CREATE TABLE IF NOT EXISTS inspection_information (
   department VARCHAR(255),
   subject_contact_information TEXT NOT NULL,
   inspection_contact_person VARCHAR(255),
-  FOREIGN KEY (draft_id) REFERENCES drafts(id)
+  FOREIGN KEY (draft_id) REFERENCES drafts(id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS target_timeframes (
@@ -53,7 +53,7 @@ CREATE TABLE IF NOT EXISTS target_timeframes (
   comments VARCHAR(255) DEFAULT NULL,
   document_id INT DEFAULT NULL,
   link_text VARCHAR(255) DEFAULT NULL,
-  FOREIGN KEY (draft_id) REFERENCES drafts(id)
+  FOREIGN KEY (draft_id) REFERENCES drafts(id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS documents (
@@ -62,7 +62,7 @@ CREATE TABLE IF NOT EXISTS documents (
   title VARCHAR(255) NOT NULL,
   handler VARCHAR(255),
   modified DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  CONSTRAINT fk_documents_drafts FOREIGN KEY (draft_id) REFERENCES drafts(id)
+  CONSTRAINT fk_documents_drafts FOREIGN KEY (draft_id) REFERENCES drafts(id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS scheduling (
@@ -71,7 +71,7 @@ CREATE TABLE IF NOT EXISTS scheduling (
   event TEXT NOT NULL,
   person TEXT NOT NULL,
   week INT NOT NULL,
-  CONSTRAINT fk_scheduling_drafts FOREIGN KEY (draft_id) REFERENCES drafts(id)
+  CONSTRAINT fk_scheduling_drafts FOREIGN KEY (draft_id) REFERENCES drafts(id) ON DELETE CASCADE
 );
 
 


### PR DESCRIPTION
Closes #128 

Finishes work started by @Vinsteri 

[GET Drafts 404 Error GPT-4.md](https://github.com/AI-Makes-IT/VTP/files/11208381/GET.Drafts.404.Error.GPT-4.md)

Summary (by ChatGPT):
This PR updates the test suite for the drafts API and makes necessary changes to the route queries to ensure correct behavior. The main changes include:

    Updated the beforeEach hook to dynamically set draft and subject IDs in the tests, and removed hardcoded values.
    Refactored the test suite to use individual describe blocks for each route.
    Fixed an issue in the GET /api/drafts/:id and GET /api/drafts/:id/full routes, where the id field from the drafts and inspection_information tables were conflicting. The id field from the drafts table is now aliased as d_id in the queries.
    Updated the tests for the GET /api/drafts/:id and GET /api/drafts/:id/full routes to check for the d_id property instead of the id property.
    Updated the foreign key constraint in the drafts table to include ON DELETE CASCADE, ensuring that related rows in child tables are deleted when a draft is deleted.

These changes improve the reliability of the test suite and ensure that the drafts API behaves as expected.