### PR TITLE
More fixes for Scheduling and Target Timeframes tests

### DIFF
--- a/backend/test/targettimeframes.test.js
+++ b/backend/test/targettimeframes.test.js
@@ -10,21 +10,55 @@ chai.should();
 const expect = chai.expect;
 
 describe('Target Timeframes API', () => {
-    beforeEach(async () => {
-        // Clean up the database
+    let createdSubjectId, createdDraftId, createdInspectionInfoId, createdTargetTimeframeId, createdDocumentId, createdSchedulingId;
+
+    before(async () => {
+        // Clear database tables before starting tests
         await db.query('DELETE FROM target_timeframes');
+        await db.query('DELETE FROM documents');
+        await db.query('DELETE FROM scheduling');
+        await db.query('DELETE FROM inspection_information');
+        await db.query('DELETE FROM drafts');
+        await db.query('DELETE FROM inspection_subject');
+    });
+
+    beforeEach(async () => {
+        // Add data needed for the tests
+        const [subjectResult] = await db.query("INSERT INTO inspection_subject (name) VALUES ('Test Subject')");
+        createdSubjectId = subjectResult.insertId;
+
+        const [draftResult] = await db.query("INSERT INTO drafts (subject_id) VALUES (?)", [createdSubjectId]);
+        createdDraftId = draftResult.insertId;
+
+        const [inspectionInfoResult] = await db.query(`INSERT INTO inspection_information (draft_id, subject_of_inspection, issue, risk_area, official_duration_period, total_duration_period, participants, responsible_inspector, office, department, subject_contact_information, inspection_contact_person)
+                            VALUES (?, 'Test Inspection', 'Test issue', 'Test risk area', '1 week', '1 week', 'John Doe', 'Inspector', 'Office', 'Department', 'Subject contact info', 'Contact person')`, [createdDraftId]);
+        createdInspectionInfoId = inspectionInfoResult.insertId;
+
+        const [targetTimeframeResult] = await db.query("INSERT INTO target_timeframes (draft_id, goal, planned_date) VALUES (?, 'Test Goal', '2023-01-01')", [createdDraftId]);
+        createdTargetTimeframeId = targetTimeframeResult.insertId;
+
+        const [documentResult] = await db.query("INSERT INTO documents (draft_id, title) VALUES (?, 'Test Document')", [createdDraftId]);
+        createdDocumentId = documentResult.insertId;
+
+        const [schedulingResult] = await db.query("INSERT INTO scheduling (draft_id, event, person, week) VALUES (?, 'Test Event', 'John Doe', 1)", [createdDraftId]);
+        createdSchedulingId = schedulingResult.insertId;
     });
 
     afterEach(async () => {
-        // Clean up the database
+        // Clear database tables after each test
         await db.query('DELETE FROM target_timeframes');
+        await db.query('DELETE FROM documents');
+        await db.query('DELETE FROM scheduling');
+        await db.query('DELETE FROM inspection_information');
+        await db.query('DELETE FROM drafts');
+        await db.query('DELETE FROM inspection_subject');
     });
 
     describe('POST /api/target_timeframes', () => {
         it('should create a new target timeframe record', async () => {
             const res = await request(app)
                 .post('/api/target_timeframes')
-                .send({ draft_id: 1, goal: 'Test goal', planned_date: '2022-01-01', actual_date: '2022-01-02', comments: 'Test comments', document_id: 1, link_text: 'Test link' });
+                .send({ draft_id: createdDraftId, goal: 'Test goal', planned_date: '2022-01-01', actual_date: '2022-01-02', comments: 'Test comments', document_id: createdDocumentId, link_text: 'Test link' });
         
             if (res.status !== 201 || typeof res.body.id !== 'number') {
                 console.error('Unexpected response body:', res.body);
@@ -48,17 +82,17 @@ describe('Target Timeframes API', () => {
         it('should retrieve the target timeframe with the given id', async () => {
             const postResponse = await request(app)
                 .post('/api/target_timeframes')
-                .send({ draft_id: 1, goal: 'Test goal', planned_date: '2022-01-01', actual_date: '2022-01-02', comments: 'Test comments', document_id: 1, link_text: 'Test link' });
+                .send({ draft_id: createdDraftId, goal: 'Test goal', planned_date: '2022-01-01', actual_date: '2022-01-02', comments: 'Test comments', document_id: createdDocumentId, link_text: 'Test link' });
 
             const targetTimeframeId = postResponse.body.id;
             const response = await chai.request(app).get(`/api/target_timeframes/${targetTimeframeId}`);
             expect(response.status).to.equal(200);
             expect(response.body).to.include({
                 id: targetTimeframeId,
-                draft_id: 1,
+                draft_id: createdDraftId,
                 goal: 'Test goal',
                 comments: 'Test comments',
-                document_id: 1,
+                document_id: createdDocumentId,
                 link_text: 'Test link'
             });
         });
@@ -74,13 +108,13 @@ describe('Target Timeframes API', () => {
         it('should update an existing target timeframe', async () => {
             const postResponse = await request(app)
                 .post('/api/target_timeframes')
-                .send({ draft_id: 1, goal: 'Test goal', planned_date: '2022-01-01', actual_date: '2022-01-02', comments: 'Test comments', document_id: 1, link_text: 'Test link' });
+                .send({ draft_id: createdDraftId, goal: 'Test goal', planned_date: '2022-01-01', actual_date: '2022-01-02', comments: 'Test comments', document_id: createdDocumentId, link_text: 'Test link' });
 
             const targetTimeframeId = postResponse.body.id;
 
             const res = await request(app)
-            .put(`/api/target_timeframes/${targetTimeframeId}`)
-            .send({ draft_id: 2, goal: 'Updated goal', planned_date: '2022-01-05', actual_date: '2022-01-06', comments: 'Updated comments', document_id: 2, link_text: 'Updated link' });
+                .put(`/api/target_timeframes/${targetTimeframeId}`)
+                .send({ draft_id: createdDraftId, goal: 'Updated goal', planned_date: '2022-01-05', actual_date: '2022-01-06', comments: 'Updated comments', document_id: createdDocumentId, link_text: 'Updated link' });
 
             assert.equal(res.status, 200);
             assert.equal(res.body.message, 'Target timeframes updated successfully');
@@ -89,10 +123,10 @@ describe('Target Timeframes API', () => {
             expect(response.status).to.equal(200);
             expect(response.body).to.include({
                 id: targetTimeframeId,
-                draft_id: 2,
+                draft_id: createdDraftId,
                 goal: 'Updated goal',
                 comments: 'Updated comments',
-                document_id: 2,
+                document_id: createdDocumentId,
                 link_text: 'Updated link'
             });
         });
@@ -111,7 +145,7 @@ describe('Target Timeframes API', () => {
         it('should delete an existing target timeframe', async () => {
             const postResponse = await request(app)
                 .post('/api/target_timeframes')
-                .send({ draft_id: 1, goal: 'Test goal', planned_date: '2022-01-01', actual_date: '2022-01-02', comments: 'Test comments', document_id: 1, link_text: 'Test link' });
+                .send({ draft_id: createdDraftId, goal: 'Test goal', planned_date: '2022-01-01', actual_date: '2022-01-02', comments: 'Test comments', document_id: createdDocumentId, link_text: 'Test link' });
 
             const targetTimeframeId = postResponse.body.id;
             const res = await request(app).delete(`/api/target_timeframes/${targetTimeframeId}`);


### PR DESCRIPTION
<details><summary>Chat logs</summary>
**You**: Our nodejs tests have before each hooks like this
'''
  let createdSubjectId, createdDraftId, createdInspectionInfoId, createdTargetTimeframeId, createdDocumentId, createdSchedulingId;

  before(async () => {
      // Clear database tables before starting tests
      await db.query('DELETE FROM target_timeframes');
      await db.query('DELETE FROM documents');
      await db.query('DELETE FROM scheduling');
      await db.query('DELETE FROM inspection_information');
      await db.query('DELETE FROM drafts');
      await db.query('DELETE FROM inspection_subject');
  });

  beforeEach(async () => {
      // Add data needed for the tests
      const [subjectResult] = await db.query("INSERT INTO inspection_subject (name) VALUES ('Test Subject')");
      createdSubjectId = subjectResult.insertId;

      const [draftResult] = await db.query("INSERT INTO drafts (subject_id) VALUES (?)", [createdSubjectId]);
      createdDraftId = draftResult.insertId;

      const [inspectionInfoResult] = await db.query(`INSERT INTO inspection_information (draft_id, subject_of_inspection, issue, risk_area, official_duration_period, total_duration_period, participants, responsible_inspector, office, department, subject_contact_information, inspection_contact_person)
                          VALUES (?, 'Test Inspection', 'Test issue', 'Test risk area', '1 week', '1 week', 'John Doe', 'Inspector', 'Office', 'Department', 'Subject contact info', 'Contact person')`, [createdDraftId]);
      createdInspectionInfoId = inspectionInfoResult.insertId;

      const [targetTimeframeResult] = await db.query("INSERT INTO target_timeframes (draft_id, goal, planned_date) VALUES (?, 'Test Goal', '2023-01-01')", [createdDraftId]);
      createdTargetTimeframeId = targetTimeframeResult.insertId;

      const [documentResult] = await db.query("INSERT INTO documents (draft_id, title) VALUES (?, 'Test Document')", [createdDraftId]);
      createdDocumentId = documentResult.insertId;

      const [schedulingResult] = await db.query("INSERT INTO scheduling (draft_id, event, person, week) VALUES (?, 'Test Event', 'John Doe', 1)", [createdDraftId]);
      createdSchedulingId = schedulingResult.insertId;
  });
'''

**ChatGPT**: It looks like you have a Node.js test setup using ```before``` and ```beforeEach``` hooks. Here's a brief explanation of the code:You have some variables declared at the beginning to store the IDs of the created records in your database tables.The ```before``` hook is used to clear the database tables before starting the tests. It deletes all records from ```target_timeframes```, ```documents```, ```scheduling```, ```inspection_information```, ```drafts```, and ```inspection_subject``` tables.The ```beforeEach``` hook is used to insert test data into the database tables before each test. It does the following:Inserts a new record into the ```inspection_subject``` table and stores the inserted ID in ```createdSubjectId```.Inserts a new record into the ```drafts``` table with the ```createdSubjectId``` and stores the inserted ID in ```createdDraftId```.Inserts a new record into the ```inspection_information``` table with the ```createdDraftId``` and stores the inserted ID in ```createdInspectionInfoId```.Inserts a new record into the ```target_timeframes``` table with the ```createdDraftId``` and stores the inserted ID in ```createdTargetTimeframeId```.Inserts a new record into the ```documents``` table with the ```createdDraftId``` and stores the inserted ID in ```createdDocumentId```.Inserts a new record into the ```scheduling``` table with the ```createdDraftId``` and stores the inserted ID in ```createdSchedulingId```.

This setup ensures that you have a clean and consistent state in the database for each test, making it easier to write and maintain tests without worrying about leftover data from previous tests affecting the results.

**You**: Update this
'''
    it('should create a new scheduling record', async () => {
      const res = await request(app)
        .post('/api/scheduling')
        .send({ draft_id: 1, event: 'New event', person: 'New person', week: 2 });
      assert.equal(res.status, 201);
      assert.isNumber(res.body.id);
    });
'''
test to use the data from the hooks

**ChatGPT**: You can update the test to use the data created by the ```beforeEach``` hook by replacing the hardcoded ```draft_id``` with ```createdDraftId```. Here's the updated test:javascript
```javascript
it('should create a new scheduling record', async () => {
  const res = await request(app)
    .post('/api/scheduling')
    .send({ draft_id: createdDraftId, event: 'New event', person: 'New person', week: 2 });
  assert.equal(res.status, 201);
  assert.isNumber(res.body.id);
});
```

Now, the test will use the ```createdDraftId``` from the ```beforeEach``` hook, making it more flexible and less dependent on hardcoded values.

**You**: Update this
'''
    it('should retrieve one scheduling record by id', async () => {
      // Insert a scheduling to get
      const insertResponse = await chai.request(app)
      .post('/api/scheduling')
      .send({ draft_id: 1, event: 'Test event', person: 'Test person', week: 1 });
      const id = insertResponse.body.id;
      const response = await chai.request(app).get(`/api/scheduling/${id}`);
      expect(response.status).to.equal(200);
      expect(response.body).to.be.an('object');
      expect(response.body).to.have.property('event', 'Test event');
      expect(response.body).to.have.property('person', 'Test person');
      expect(response.body).to.have.property('week', 1);
    });
'''
test to use the data from the hooks

**ChatGPT**: You can update the test to use the data created by the ```beforeEach``` hook by replacing the hardcoded ```draft_id``` with ```createdDraftId```. Here's the updated test:javascript
```javascript
it('should retrieve one scheduling record by id', async () => {
  // Insert a scheduling to get
  const insertResponse = await chai.request(app)
    .post('/api/scheduling')
    .send({ draft_id: createdDraftId, event: 'Test event', person: 'Test person', week: 1 });
  const id = insertResponse.body.id;
  const response = await chai.request(app).get(`/api/scheduling/${id}`);
  expect(response.status).to.equal(200);
  expect(response.body).to.be.an('object');
  expect(response.body).to.have.property('event', 'Test event');
  expect(response.body).to.have.property('person', 'Test person');
  expect(response.body).to.have.property('week', 1);
});
```

Now, the test will use the ```createdDraftId``` from the ```beforeEach``` hook, making it more flexible and less dependent on hardcoded values.

**You**: Update this
'''
    it('should delete a scheduling and return a 200 status code with a message', async () => {
      // Insert a scheduling to delete
      const insertResponse = await chai.request(app)
        .post('/api/scheduling')
        .send({ draft_id: 1, event: 'Delete event', person: 'Delete person', week: 2 });
      const schedulingId = insertResponse.body.id;

      // Delete the scheduling
      const deleteResponse = await chai.request(app).delete(`/api/scheduling/${schedulingId}`);
      expect(deleteResponse).to.have.status(200);
      expect(deleteResponse.body).to.deep.equal({ message: 'Scheduling deleted successfully' });

      // Check that the scheduling was deleted
      const getResponse = await chai.request(app).get(`/api/scheduling/${schedulingId}`);
      expect(getResponse).to.have.status(404);
      expect(getResponse.body).to.deep.equal({ error: `Scheduling not found` });
    });
'''
test to use the data from the hooks

**ChatGPT**: You can update the test to use the data created by the ```beforeEach``` hook by replacing the hardcoded ```draft_id``` with ```createdDraftId```. Here's the updated test:javascript
```javascript
it('should delete a scheduling and return a 200 status code with a message', async () => {
  // Insert a scheduling to delete
  const insertResponse = await chai.request(app)
    .post('/api/scheduling')
    .send({ draft_id: createdDraftId, event: 'Delete event', person: 'Delete person', week: 2 });
  const schedulingId = insertResponse.body.id;

  // Delete the scheduling
  const deleteResponse = await chai.request(app).delete(`/api/scheduling/${schedulingId}`);
  expect(deleteResponse).to.have.status(200);
  expect(deleteResponse.body).to.deep.equal({ message: 'Scheduling deleted successfully' });

  // Check that the scheduling was deleted
  const getResponse = await chai.request(app).get(`/api/scheduling/${schedulingId}`);
  expect(getResponse).to.have.status(404);
  expect(getResponse.body).to.deep.equal({ error: `Scheduling not found` });
});
```

Now, the test will use the ```createdDraftId``` from the ```beforeEach``` hook, making it more flexible and less dependent on hardcoded values.

**You**: Update these
'''
    // Test updating an existing scheduling
    it('should update an existing scheduling', async () => {
      const res = await chai
        .request(app)
        .put(`/api/scheduling/${schedulingId}`)
        .send({
          draft_id: 2,
          event: 'Updated event',
          person: 'Updated person',
          week: 3,
        });
      expect(res).to.have.status(200);
  
      const updatedScheduling = await db.query('SELECT * FROM scheduling WHERE id = ?', [
        schedulingId,
      ]);
      expect(updatedScheduling[0]).to.deep.include({
        id: schedulingId,
        draft_id: 2,
        event: 'Updated event',
        person: 'Updated person',
        week: 3,
      });
    });
  
    // Test updating a non-existent scheduling
    it('should return a 404 error if the scheduling does not exist', async () => {
      const res = await chai
        .request(app)
        .put('/api/scheduling/999')
        .send({
          draft_id: 2,
          event: 'Updated event',
          person: 'Updated person',
          week: 3,
        });
      expect(res).to.have.status(404);
      expect(res.body).to.deep.equal({ error: 'Scheduling not found' });
    });
  });
'''
tests to use the data from the hooks

**ChatGPT**: You can update the tests to use the data created by the ```beforeEach``` hook by replacing hardcoded ```draft_id``` and ```schedulingId``` values with ```createdDraftId``` and ```createdSchedulingId```. Here are the updated tests:javascript
```javascript
// Test updating an existing scheduling
it('should update an existing scheduling', async () => {
  const res = await chai
    .request(app)
    .put(`/api/scheduling/${createdSchedulingId}`)
    .send({
      draft_id: createdDraftId,
      event: 'Updated event',
      person: 'Updated person',
      week: 3,
    });
  expect(res).to.have.status(200);

  const updatedScheduling = await db.query('SELECT * FROM scheduling WHERE id = ?', [
    createdSchedulingId,
  ]);
  expect(updatedScheduling[0]).to.deep.include({
    id: createdSchedulingId,
    draft_id: createdDraftId,
    event: 'Updated event',
    person: 'Updated person',
    week: 3,
  });
});

// Test updating a non-existent scheduling
it('should return a 404 error if the scheduling does not exist', async () => {
  const nonExistentSchedulingId = 999;
  const res = await chai
    .request(app)
    .put(`/api/scheduling/${nonExistentSchedulingId}`)
    .send({
      draft_id: createdDraftId,
      event: 'Updated event',
      person: 'Updated person',
      week: 3,
    });
  expect(res).to.have.status(404);
  expect(res.body).to.deep.equal({ error: 'Scheduling not found' });
});
```

Now, the tests will use the ```createdDraftId``` and ```createdSchedulingId``` from the ```beforeEach``` hook, making them more flexible and less dependent on hardcoded values.

**You**: Update this
'''
        it('should create a new target timeframe record', async () => {
            const res = await request(app)
                .post('/api/target_timeframes')
                .send({ draft_id: 1, goal: 'Test goal', planned_date: '2022-01-01', actual_date: '2022-01-02', comments: 'Test comments', document_id: 1, link_text: 'Test link' });
        
            if (res.status !== 201 || typeof res.body.id !== 'number') {
                console.error('Unexpected response body:', res.body);
            }
        
            assert.equal(res.status, 201);
            assert.isNumber(res.body.id);
        });
'''
test to use the data from the hooks

**ChatGPT**: You can update the test to use the data created by the ```beforeEach``` hook by replacing the hardcoded ```draft_id``` and ```document_id``` with ```createdDraftId``` and ```createdDocumentId```. Here's the updated test:javascript
```javascript
it('should create a new target timeframe record', async () => {
  const res = await request(app)
    .post('/api/target_timeframes')
    .send({ draft_id: createdDraftId, goal: 'Test goal', planned_date: '2022-01-01', actual_date: '2022-01-02', comments: 'Test comments', document_id: createdDocumentId, link_text: 'Test link' });

  if (res.status !== 201 || typeof res.body.id !== 'number') {
    console.error('Unexpected response body:', res.body);
  }

  assert.equal(res.status, 201);
  assert.isNumber(res.body.id);
});
```

Now, the test will use the ```createdDraftId``` and ```createdDocumentId``` from the ```beforeEach``` hook, making it more flexible and less dependent on hardcoded values.

**You**: Update this
'''
        it('should retrieve the target timeframe with the given id', async () => {
            const postResponse = await request(app)
                .post('/api/target_timeframes')
                .send({ draft_id: 1, goal: 'Test goal', planned_date: '2022-01-01', actual_date: '2022-01-02', comments: 'Test comments', document_id: 1, link_text: 'Test link' });

            const targetTimeframeId = postResponse.body.id;
            const response = await chai.request(app).get(`/api/target_timeframes/${targetTimeframeId}`);
            expect(response.status).to.equal(200);
            expect(response.body).to.include({
                id: targetTimeframeId,
                draft_id: 1,
                goal: 'Test goal',
                comments: 'Test comments',
                document_id: 1,
                link_text: 'Test link'
            });
        });
'''
test to use the data from the hooks

**ChatGPT**: You can update the test to use the data created by the ```beforeEach``` hook by replacing the hardcoded ```draft_id``` and ```document_id``` with ```createdDraftId``` and ```createdDocumentId```. Here's the updated test:javascript
```javascript
it('should retrieve the target timeframe with the given id', async () => {
  const postResponse = await request(app)
    .post('/api/target_timeframes')
    .send({ draft_id: createdDraftId, goal: 'Test goal', planned_date: '2022-01-01', actual_date: '2022-01-02', comments: 'Test comments', document_id: createdDocumentId, link_text: 'Test link' });

  const targetTimeframeId = postResponse.body.id;
  const response = await chai.request(app).get(`/api/target_timeframes/${targetTimeframeId}`);
  expect(response.status).to.equal(200);
  expect(response.body).to.include({
    id: targetTimeframeId,
    draft_id: createdDraftId,
    goal: 'Test goal',
    comments: 'Test comments',
    document_id: createdDocumentId,
    link_text: 'Test link'
  });
});
```

Now, the test will use the ```createdDraftId``` and ```createdDocumentId``` from the ```beforeEach``` hook, making it more flexible and less dependent on hardcoded values.

**You**: Update this
'''
        it('should update an existing target timeframe', async () => {
            const postResponse = await request(app)
                .post('/api/target_timeframes')
                .send({ draft_id: 1, goal: 'Test goal', planned_date: '2022-01-01', actual_date: '2022-01-02', comments: 'Test comments', document_id: 1, link_text: 'Test link' });

            const targetTimeframeId = postResponse.body.id;

            const res = await request(app)
            .put(`/api/target_timeframes/${targetTimeframeId}`)
            .send({ draft_id: 2, goal: 'Updated goal', planned_date: '2022-01-05', actual_date: '2022-01-06', comments: 'Updated comments', document_id: 2, link_text: 'Updated link' });

            assert.equal(res.status, 200);
            assert.equal(res.body.message, 'Target timeframes updated successfully');

            const response = await chai.request(app).get(`/api/target_timeframes/${targetTimeframeId}`);
            expect(response.status).to.equal(200);
            expect(response.body).to.include({
                id: targetTimeframeId,
                draft_id: 2,
                goal: 'Updated goal',
                comments: 'Updated comments',
                document_id: 2,
                link_text: 'Updated link'
            });
        });
'''
test to use the data from the hooks

**ChatGPT**: You can update the test to use the data created by the ```beforeEach``` hook by replacing the hardcoded ```draft_id``` and ```document_id``` values in both the ```post``` and ```put``` requests with ```createdDraftId``` and ```createdDocumentId```. Here's the updated test:javascript
```javascript
it('should update an existing target timeframe', async () => {
  const postResponse = await request(app)
    .post('/api/target_timeframes')
    .send({ draft_id: createdDraftId, goal: 'Test goal', planned_date: '2022-01-01', actual_date: '2022-01-02', comments: 'Test comments', document_id: createdDocumentId, link_text: 'Test link' });

  const targetTimeframeId = postResponse.body.id;

  const res = await request(app)
    .put(`/api/target_timeframes/${targetTimeframeId}`)
    .send({ draft_id: createdDraftId, goal: 'Updated goal', planned_date: '2022-01-05', actual_date: '2022-01-06', comments: 'Updated comments', document_id: createdDocumentId, link_text: 'Updated link' });

  assert.equal(res.status, 200);
  assert.equal(res.body.message, 'Target timeframes updated successfully');

  const response = await chai.request(app).get(`/api/target_timeframes/${targetTimeframeId}`);
  expect(response.status).to.equal(200);
  expect(response.body).to.include({
    id: targetTimeframeId,
    draft_id: createdDraftId,
    goal: 'Updated goal',
    comments: 'Updated comments',
    document_id: createdDocumentId,
    link_text: 'Updated link'
  });
});
```

Now, the test will use the ```createdDraftId``` and ```createdDocumentId``` from the ```beforeEach``` hook, making it more flexible and less dependent on hardcoded values.

**You**: Update this
'''
        it('should delete an existing target timeframe', async () => {
            const postResponse = await request(app)
                .post('/api/target_timeframes')
                .send({ draft_id: 1, goal: 'Test goal', planned_date: '2022-01-01', actual_date: '2022-01-02', comments: 'Test comments', document_id: 1, link_text: 'Test link' });

            const targetTimeframeId = postResponse.body.id;
            const res = await request(app).delete(`/api/target_timeframes/${targetTimeframeId}`);

            assert.equal(res.status, 200);
            assert.equal(res.body.message, 'Target timeframes deleted successfully');
        });
'''
test to use the data from the hooks

**ChatGPT**: You can update the test to use the data created by the ```beforeEach``` hook by replacing the hardcoded ```draft_id``` and ```document_id``` with ```createdDraftId``` and ```createdDocumentId```. Here's the updated test:javascript
```javascript
it('should delete an existing target timeframe', async () => {
  const postResponse = await request(app)
    .post('/api/target_timeframes')
    .send({ draft_id: createdDraftId, goal: 'Test goal', planned_date: '2022-01-01', actual_date: '2022-01-02', comments: 'Test comments', document_id: createdDocumentId, link_text: 'Test link' });

  const targetTimeframeId = postResponse.body.id;
  const res = await request(app).delete(`/api/target_timeframes/${targetTimeframeId}`);

  assert.equal(res.status, 200);
  assert.equal(res.body.message, 'Target timeframes deleted successfully');
});
```

Now, the test will use the ```createdDraftId``` and ```createdDocumentId``` from the ```beforeEach``` hook, making it more flexible and less dependent on hardcoded values.

**You**: ty

**ChatGPT**: You're welcome! If you have any more questions or need further assistance, feel free to ask. Good luck with your tests!


</details>
