### PR TITLE
Fix failing Mocha test for retrieving all drafts of an inspection subject

### DIFF
--- a/backend/test/inspection_subjects.test.js
+++ b/backend/test/inspection_subjects.test.js
@@ -93,7 +93,7 @@ describe('Inspection Subjects API', () => {
         it('should retrieve all drafts for a given inspection subject', async () => {
             const [sub] = await db.query('INSERT INTO inspection_subject (name) VALUES (?)', ['Subject 1']);
             const [draft] = await db.query('INSERT INTO drafts (subject_id) VALUES (?)', [sub.insertId]);
-            await db.query('INSERT INTO inspection_information (draft_id, issue) VALUES (?, ?)', [draft.insertId, 'Issue 1']);
+            await db.query('INSERT INTO inspection_information (draft_id, issue, risk_area, official_duration_period, total_duration_period, participants, responsible_inspector, subject_contact_information) VALUES (?, ?, ?, ?, ?, ?, ?, ?)', [draft.insertId, 'Issue 1', 'Risk Area 1', '1 day', '1 day', 'John Doe', 'Inspector 1', 'Contact info']);
             const res = await chai.request(app).get(`/api/inspection_subjects/${sub.insertId}/drafts`);
             expect(res.status).to.equal(200);
             expect(res.body).to.be.an('array');


### PR DESCRIPTION
Closes #136 

[Mocha Test Fails GPT-4.md](https://github.com/AI-Makes-IT/VTP/files/11223407/Mocha.Test.Fails.GPT-4.md)


Description:

This pull request addresses a failing Mocha test in our test suite. The test aimed to retrieve all drafts for a given inspection subject, but it was failing due to missing required fields when inserting a record into the inspection_information table.

Changes:

    Updated the test case in inspection_subjects.test.js to include values for the missing fields risk_area, official_duration_period, total_duration_period, participants, responsible_inspector, and subject_contact_information. These fields are marked as NOT NULL in the table definition and thus require values during insertion.

Impact:

By fixing this test, we can ensure the correctness of the test suite and prevent false negatives. This change will also help us maintain the integrity of the test suite as new features and updates are added to the codebase.

Testing:

    Make sure the updated test case passes when running the test suite.
    No other tests should be affected by this change, as it is limited to the specific test case.

Please review this pull request, and let me know if you have any questions or concerns.